### PR TITLE
fix_hp_0707 remove hardcoded hostpool value in line 103

### DIFF
--- a/wvd-springrelease-workbook.json
+++ b/wvd-springrelease-workbook.json
@@ -100,7 +100,6 @@
             "crossComponentResources": [
               "{Subscription}"
             ],
-            "value": "thovuy-pool",
             "typeSettings": {
               "additionalResourceOptions": []
             },


### PR DESCRIPTION
works as expected without any "value" key, not sure if there is a reason to retain the key without a value, or as 'value::all' instead ?. 